### PR TITLE
fix compile error on 32bit platforms

### DIFF
--- a/.github/compile_check.sh
+++ b/.github/compile_check.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e 
+dist_list=$(go tool dist list)
+
+for dist in ${dist_list}; do
+    GOOS=$(echo "${dist}" | cut  -d "/" -f 1)
+    GOARCH=$(echo "${dist}" | cut -d "/" -f 2)
+    set +e
+    
+    if ! GOOS=${GOOS} GOARCH=${GOARCH} go tool compile -V > /dev/null 2>&1; then
+        echo "Compile support for ${GOOS}/${GOARCH} is not provided; skipping"
+        continue
+    fi
+    set -e
+    echo "Building  ${GOOS}/${GOARCH}"
+    GOOS=${GOOS} GOARCH=${GOARCH} go build  -o /dev/null
+done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
           - "1.19"
           - "1.18"
           - "1.17"
-          - "1.16"
 
     steps:
       - name: Prepare git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - uses: actions/checkout@v3
-
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v4
         with:
@@ -48,3 +47,13 @@ jobs:
       - uses: shogo82148/actions-goveralls@v1
         with:
           parallel-finished: true
+
+  compile-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "latest"
+      - run: |
+          ./.github/compile_check.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "latest"
+          go-version: "stable"
       - run: |
           ./.github/compile_check.sh

--- a/encode.go
+++ b/encode.go
@@ -58,14 +58,16 @@ func (s *encodeState) encodeBareItem(v Value) error {
 	case int:
 		return s.encodeInteger(int64(v))
 	case uint:
-		if v > MaxInteger {
+		w := int(v) // this cast may overflow,
+		if w < 0 {  // so we need to check it.
 			return fmt.Errorf("sfv: integer %d is out of range", v)
 		}
 		return s.encodeInteger(int64(v))
 	case int64:
 		return s.encodeInteger(v)
 	case uint64:
-		if v > MaxInteger {
+		w := int64(v) // this cast may overflow,
+		if w < 0 {    // so we need to check it.
 			return fmt.Errorf("sfv: integer %d is out of range", v)
 		}
 		return s.encodeInteger(int64(v))

--- a/encode_test.go
+++ b/encode_test.go
@@ -69,8 +69,10 @@ func TestEncodeIntegers(t *testing.T) {
 	test(Item{
 		Value: uint64(123),
 	})
+}
 
-	// Boundary value check
+// Boundary value check
+func TestEncodeIntegers_boundary(t *testing.T) {
 	val, err := EncodeItem(Item{
 		Value: int64(MaxInteger),
 	})
@@ -103,6 +105,39 @@ func TestEncodeIntegers(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("want error, not not")
+	}
+
+	val, err = EncodeItem(Item{
+		Value: uint64(MaxInteger),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if val != "999999999999999" {
+		t.Errorf("want 999999999999999, got %q", val)
+	}
+
+	_, err = EncodeItem(Item{
+		Value: uint64(MaxInteger + 1),
+	})
+	if err == nil {
+		t.Error("want error, not not")
+	}
+
+	_, err = EncodeItem(Item{
+		Value: uint64(math.MaxInt64 + 1),
+	})
+	if err == nil {
+		t.Error("want error, not not")
+	}
+
+	if math.MaxInt >= MaxInteger {
+		_, err = EncodeItem(Item{
+			Value: uint(math.MaxInt64 + 1),
+		})
+		if err == nil {
+			t.Error("want error, not not")
+		}
 	}
 }
 


### PR DESCRIPTION
It fails with overflow error.

```
# github.com/shogo82148/go-sfv
./encode.go:61:10: MaxInteger (untyped int constant 999999999999999) overflows uint
```