### PR TITLE
Reduce buffer allocation in base64 encoding

### DIFF
--- a/any.go
+++ b/any.go
@@ -1,0 +1,4 @@
+package sfv
+
+// any is an alias for interface{}, added in go1.18.
+type any = interface{}


### PR DESCRIPTION
bytes.Buffer.AvailableBuffer is available from Go 1.21.0.

- https://pkg.go.dev/bytes#Buffer.AvailableBuffer

use it to reduce buffer allocation in base64 encoding.

```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-sfv
                       │   .old.txt   │               .new.txt               │
                       │    sec/op    │    sec/op     vs base                │
DecodeInteger-10          59.36n ± 0%    59.99n ± 1%   +1.06% (p=0.000 n=10)
DecodeDecimal-10          61.95n ± 1%    61.53n ± 1%        ~ (p=0.592 n=10)
DecodeString-10           68.49n ± 1%    70.27n ± 2%   +2.60% (p=0.000 n=10)
DecodeToken-10            64.42n ± 1%    66.61n ± 1%   +3.42% (p=0.000 n=10)
DecodeBinary-10           98.52n ± 0%   101.30n ± 2%   +2.82% (p=0.000 n=10)
DecodeBoolean-10          19.89n ± 2%    20.03n ± 0%   +0.70% (p=0.045 n=10)
DecodeDate-10             71.98n ± 1%    68.04n ± 1%   -5.47% (p=0.000 n=10)
DecodeDisplayString-10    294.3n ± 2%    291.4n ± 4%        ~ (p=0.468 n=10)
DecodeItem-10             1.646µ ± 2%    1.627µ ± 2%        ~ (p=0.063 n=10)
DecodeList-10             1.736m ± 1%    1.741m ± 1%        ~ (p=0.971 n=10)
DecodeDictionary-10       2.000m ± 1%    1.993m ± 3%        ~ (p=0.971 n=10)
EncodeInteger-10          45.61n ± 2%    44.71n ± 0%   -1.96% (p=0.000 n=10)
EncodeDecimal-10          53.09n ± 1%    53.77n ± 1%   +1.28% (p=0.015 n=10)
EncodeString-10           58.38n ± 1%    63.72n ± 1%   +9.14% (p=0.000 n=10)
EncodeToken-10            32.12n ± 1%    31.68n ± 2%        ~ (p=0.066 n=10)
EncodeBinary-10          214.65n ± 8%    53.97n ± 1%  -74.86% (p=0.000 n=10)
EncodeBoolean-10          27.33n ± 1%    27.22n ± 1%        ~ (p=0.271 n=10)
EncodeDate-10             45.62n ± 2%    43.94n ± 1%   -3.69% (p=0.000 n=10)
EncodeDisplayString-10    191.8n ± 3%    194.3n ± 2%        ~ (p=0.382 n=10)
EncodeItem-10             753.4n ± 4%    462.2n ± 1%  -38.66% (p=0.000 n=10)
EncodeList-10             778.6µ ± 6%    455.4µ ± 1%  -41.51% (p=0.000 n=10)
EncodeDictionary-10       787.3µ ± 3%    458.2µ ± 1%  -41.80% (p=0.000 n=10)
geomean                   512.7n         449.6n       -12.31%

                       │    .old.txt     │                .new.txt                │
                       │      B/op       │     B/op      vs base                  │
DecodeInteger-10            8.000 ± 0%       8.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeDecimal-10            8.000 ± 0%       8.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeString-10             24.00 ± 0%       24.00 ± 0%        ~ (p=1.000 n=10) ¹
DecodeToken-10              24.00 ± 0%       24.00 ± 0%        ~ (p=1.000 n=10) ¹
DecodeBinary-10             91.00 ± 0%       91.00 ± 0%        ~ (p=1.000 n=10) ¹
DecodeBoolean-10            0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeDate-10               24.00 ± 0%       24.00 ± 0%        ~ (p=1.000 n=10) ¹
DecodeDisplayString-10      72.00 ± 0%       72.00 ± 0%        ~ (p=1.000 n=10) ¹
DecodeItem-10               952.0 ± 0%       952.0 ± 0%        ~ (p=1.000 n=10) ¹
DecodeList-10             1.010Mi ± 0%     1.010Mi ± 0%        ~ (p=0.653 n=10)
DecodeDictionary-10       1.168Mi ± 0%     1.168Mi ± 0%        ~ (p=0.956 n=10)
EncodeInteger-10            16.00 ± 0%       16.00 ± 0%        ~ (p=1.000 n=10) ¹
EncodeDecimal-10            24.00 ± 0%       24.00 ± 0%        ~ (p=1.000 n=10) ¹
EncodeString-10             16.00 ± 0%       16.00 ± 0%        ~ (p=1.000 n=10) ¹
EncodeToken-10              5.000 ± 0%       5.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodeBinary-10           1200.00 ± 0%       48.00 ± 0%  -96.00% (p=0.000 n=10)
EncodeBoolean-10            2.000 ± 0%       2.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodeDate-10               16.00 ± 0%       16.00 ± 0%        ~ (p=1.000 n=10) ¹
EncodeDisplayString-10      64.00 ± 0%       64.00 ± 0%        ~ (p=1.000 n=10) ¹
EncodeItem-10              2560.0 ± 0%       256.0 ± 0%  -90.00% (p=0.000 n=10)
EncodeList-10            2553.0Ki ± 0%     248.3Ki ± 0%  -90.28% (p=0.000 n=10)
EncodeDictionary-10      2561.3Ki ± 0%     256.2Ki ± 0%  -90.00% (p=0.000 n=10)
geomean                                ²                 -36.97%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                       │    .old.txt     │               .new.txt                │
                       │    allocs/op    │  allocs/op   vs base                  │
DecodeInteger-10            1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeDecimal-10            1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeString-10             2.000 ± 0%      2.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeToken-10              2.000 ± 0%      2.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeBinary-10             3.000 ± 0%      3.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeBoolean-10            0.000 ± 0%      0.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeDate-10               1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeDisplayString-10      4.000 ± 0%      4.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodeItem-10               30.00 ± 0%      30.00 ± 0%        ~ (p=1.000 n=10) ¹
DecodeList-10              30.73k ± 0%     30.73k ± 0%        ~ (p=1.000 n=10) ¹
DecodeDictionary-10        31.78k ± 0%     31.78k ± 0%        ~ (p=1.000 n=10)
EncodeInteger-10            1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodeDecimal-10            1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodeString-10             1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodeToken-10              1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodeBinary-10             2.000 ± 0%      1.000 ± 0%  -50.00% (p=0.000 n=10)
EncodeBoolean-10            1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodeDate-10               1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodeDisplayString-10      1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodeItem-10               3.000 ± 0%      1.000 ± 0%  -66.67% (p=0.000 n=10)
EncodeList-10            2050.000 ± 0%      1.000 ± 0%  -99.95% (p=0.000 n=10)
EncodeDictionary-10      2050.000 ± 0%      1.000 ± 0%  -99.95% (p=0.000 n=10)
geomean                                ²                -53.91%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```