### PR TITLE
sync test cases with https://github.com/httpwg/structured-field-tests/commit/6764b0a6cf4b7203eb50934f40d8f2201bd1e18a

### DIFF
--- a/testdata/structured-field-tests/README.md
+++ b/testdata/structured-field-tests/README.md
@@ -27,6 +27,7 @@ The `expected` data structure maps the types in Structured Fields to [JSON](http
    * String: JSON string; e.g., "foo"
    * Token: `token` __type Object (see below)
    * Binary Content: `binary` __type Object (see below)
+   * Boolean: JSON boolean; e.g., true
    * Date: `date` __type Object (see below)
    * Display String: `displaystring` __type Object (see below)
 * Parameters: JSON array of arrays with two element, the param name and the param value

--- a/testdata/structured-field-tests/display-string.json
+++ b/testdata/structured-field-tests/display-string.json
@@ -6,6 +6,12 @@
         "expected": [{"__type": "displaystring", "value": "foo bar"}, []]
     },
     {
+        "name": "all printable ascii",
+        "raw": ["%\" !%22#$%25&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\""],
+        "header_type": "item",
+        "expected": [{"__type": "displaystring", "value": " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"}, []]
+    },
+    {
         "name": "non-ascii display string (uppercase escaping)",
         "raw": ["%\"f%C3%BC%C3%BC\""],
         "canonical": ["%\"f%c3%bc%c3%bc\""],
@@ -33,6 +39,18 @@
     {
         "name": "single quoted display string",
         "raw": ["%'foo'"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "unquoted display string",
+        "raw": ["%foo"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "display string missing initial quote",
+        "raw": ["%foo\""],
         "header_type": "item",
         "must_fail": true
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to reflect the addition of Boolean type support in the structured field tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->