### PR TITLE
add Go 1.22 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
           - ubuntu-latest
         go:
           - "1"
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"
@@ -19,13 +20,6 @@ jobs:
         arch:
           - amd64 # int has 64bit
           - "386" # int has 32bit
-        goexperiment: [""]
-        include:
-          # test with GOEXPERIMENT=loopvar
-          # https://github.com/golang/go/wiki/LoopvarExperiment
-          - os: ubuntu-latest
-            go: "1.21"
-            goexperiment: "loopvar"
 
     steps:
       - name: Prepare git
@@ -42,7 +36,6 @@ jobs:
         shell: bash
         run: go test -v -coverprofile=profile.cov ./...
         env:
-          GOEXPERIMENT: ${{ matrix.goexperiment }}
           GOARCH: ${{ matrix.arch }}
 
       - uses: shogo82148/actions-goveralls@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Go version support in automated tests.
	- Removed deprecated Go experiment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->