### PR TITLE
introduce GitHub native coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,5 +37,5 @@ jobs:
         with:
           file: coverage.xml
           language: go
-          label: code-overage/go-1.26
+          label: code-coverage/go-1.26
           fail-on-error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Test and collect coverage
         shell: bash
         run: go test -v -coverprofile=profile.cov ./...
+      - name: Convert coverage to Cobertura format
+        run: |
+          go install github.com/boumenot/gocover-cobertura@v1.5.0
+          gocover-cobertura < profile.cov > coverage.xml
 
       - name: Upload coverage report
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - name: Set up Go 1.26
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Code Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  code-quality: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare git
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Go 1.26
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+
+      - name: Test and collect coverage
+        shell: bash
+        run: go test -v -coverprofile=profile.cov ./...
+
+      - name: Upload coverage report
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@b51da2c3c1b23e04d2d6477cfc34350b1f5cd3e9 # v1.2.0
+        with:
+          file: coverage.xml
+          language: go
+          label: code-overage/go-1.26
+          fail-on-error: false


### PR DESCRIPTION
https://github.blog/changelog/2026-05-26-code-coverage-in-pull-requests-is-now-in-public-preview/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI code-coverage workflow for Go that runs on pushes and pull requests to main, executes tests across packages, generates coverage reports, and uploads them when permitted. Uploads are non-blocking on failure and include Go version metadata.

* **Notes**
  * No user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shogo82148/go-sfv/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->